### PR TITLE
Miscellaneous doc improvements

### DIFF
--- a/datadogriver/README.md
+++ b/datadogriver/README.md
@@ -1,0 +1,8 @@
+# datadogriver
+
+This package demonstrates the use of the [`otelriver`](../otelriver/) package with [DataDog's OpenTelemetry provider](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/go/otel/). This is provided as an alternative to direct integration with DataDog's Go SDK.
+
+See:
+
+* [`example_global_provider_test.go`](./example_global_provider_test.go): Usage with global tracer provider.
+* [`example_injected_provider_test.go`](./example_injected_provider_test.go): Usage with tracer provider injected as configuration.

--- a/datadogriver/doc.go
+++ b/datadogriver/doc.go
@@ -1,4 +1,4 @@
-// Package datadogriver demonstrates the use of the otelriver package
-// with DataDog's OpenTelemetry provider. This is provided as an alternative to
+// Package datadogriver demonstrates the use of the otelriver package with
+// DataDog's OpenTelemetry provider. This is provided as an alternative to
 // direct integration with DataDog's Go SDK.
 package datadogriver

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,3 +1,8 @@
 # rivercontrib
 
 [River](https://github.com/riverqueue/river) packages for third party systems.
+
+See:
+
+* [`datadogriver`](../datadogriver): Package containing examples of using `otelriver` with [DataDog](https://www.datadoghq.com/).
+* [`otelriver`](../otelriver): Package for use with [OpenTelemetry](https://opentelemetry.io/).

--- a/otelriver/README.md
+++ b/otelriver/README.md
@@ -6,4 +6,4 @@ See [`example_middleware_test.go`](./example_middleware_test.go) for usage detai
 
 ## Use with DataDog
 
-See [using the OpenTelemetry API with DataDog](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/go/otel/) for instructions on how to configure a DataDog OpenTelemetry tracer provider.
+See [using the OpenTelemetry API with DataDog](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/go/otel/) and the examples in [`datadogriver`](../datadogriver/) for how to configure a DataDog OpenTelemetry tracer provider.


### PR DESCRIPTION
A few miscellaneous doc improvements:

* Add `datadogriver/README.md` containing package description and links
  to examples.

* Link to each subpackage from top level `README.md` and with
  descriptions for each.

* Link to `datadogriver` package from `otelriver` in the "using with
  DataDog" section.