### PR TITLE
A few additional metrics + attributes + units + panic handling

### DIFF
--- a/otelriver/middleware.go
+++ b/otelriver/middleware.go
@@ -4,6 +4,7 @@ package otelriver
 
 import (
 	"context"
+	"time"
 
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
@@ -45,8 +46,12 @@ type Middleware struct {
 
 // Bundle of metrics associated with a middleware.
 type middlewareMetrics struct {
-	insertCount metric.Int64Counter
-	workCount   metric.Int64Counter
+	jobWork                    metric.Int64Counter
+	jobWorkDuration            metric.Float64Gauge
+	jobWorkDurationHistogram   metric.Float64Histogram
+	jobInsert                  metric.Int64Counter
+	jobInsertDuration          metric.Float64Gauge
+	jobInsertDurationHistogram metric.Float64Histogram
 }
 
 // NewMiddleware initializes a new River OpenTelemetry middleware.
@@ -68,19 +73,18 @@ func NewMiddleware(config *MiddlewareConfig) *Middleware {
 
 	meter := meterProvider.Meter(name)
 
-	mustInt64Counter := func(name string, options ...metric.Int64CounterOption) metric.Int64Counter {
-		metric, err := meter.Int64Counter(name, options...)
-		if err != nil {
-			panic(err)
-		}
-		return metric
-	}
-
 	return &Middleware{
 		meter: meter,
 		metrics: middlewareMetrics{
-			insertCount: mustInt64Counter(prefix+"jobs_inserted", metric.WithDescription("Number of jobs inserted")),
-			workCount:   mustInt64Counter(prefix+"jobs_worked", metric.WithDescription("Number of jobs worked")),
+			// See unit guidelines:
+			//
+			// https://opentelemetry.io/docs/specs/semconv/general/metrics/#instrument-units
+			jobInsert:                  mustInt64Counter(meter, prefix+"job_insert", metric.WithDescription("Number of jobs inserted"), metric.WithUnit("{job}")),
+			jobInsertDuration:          mustFloat64Gauge(meter, prefix+"job_insert_duration", metric.WithDescription("Duration of insertion of job batch"), metric.WithUnit("s")),
+			jobInsertDurationHistogram: mustFloat64Histogram(meter, prefix+"job_insert_duration_histogram", metric.WithDescription("Duration of insertion of job batch (histogram)"), metric.WithUnit("s")),
+			jobWork:                    mustInt64Counter(meter, prefix+"job_work", metric.WithDescription("Number of jobs worked"), metric.WithUnit("{job}")),
+			jobWorkDuration:            mustFloat64Gauge(meter, prefix+"job_work_duration", metric.WithDescription("Duration of job being worked"), metric.WithUnit("s")),
+			jobWorkDurationHistogram:   mustFloat64Histogram(meter, prefix+"job_work_duration_histogram", metric.WithDescription("Duration of job being worked (histogram)"), metric.WithUnit("s")),
 		},
 		tracer: tracerProvider.Tracer(name),
 	}
@@ -90,37 +94,112 @@ func (m *Middleware) InsertMany(ctx context.Context, manyParams []*rivertype.Job
 	ctx, span := m.tracer.Start(ctx, prefix+"insert_many")
 	defer span.End()
 
-	insertRes, err := doInner(ctx)
-	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-		return insertRes, err
+	attrs := []attribute.KeyValue{
+		attribute.String("status", ""), // replaced below
 	}
+	const statusIndex = 0
 
-	span.SetStatus(codes.Ok, "")
-	m.metrics.insertCount.Add(ctx, int64(len(manyParams)))
+	var (
+		begin     = time.Now()
+		err       error
+		insertRes []*rivertype.JobInsertResult
+		panicked  = true // set to false if program leaves normally
+	)
+	defer func() {
+		durationSeconds := time.Since(begin).Seconds()
 
-	return insertRes, nil
+		setAttributeAndSpanStatus(attrs, statusIndex, span, panicked, err)
+
+		// This allocates a new slice, so make sure to do it as few times as possible.
+		measurementOpt := metric.WithAttributes(attrs...)
+
+		m.metrics.jobInsert.Add(ctx, int64(len(manyParams)))
+		m.metrics.jobInsertDuration.Record(ctx, durationSeconds, measurementOpt)
+		m.metrics.jobInsertDurationHistogram.Record(ctx, durationSeconds, measurementOpt)
+	}()
+
+	insertRes, err = doInner(ctx)
+	panicked = false
+	return insertRes, err
 }
 
 func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
 	ctx, span := m.tracer.Start(ctx, prefix+"work")
 	defer span.End()
 
-	attributes := []attribute.KeyValue{
+	attrs := []attribute.KeyValue{
 		attribute.Int("attempt", job.Attempt),
 		attribute.String("kind", job.Kind),
 		attribute.String("queue", job.Queue),
+		attribute.String("status", ""), // replaced below
 	}
-	span.SetAttributes(attributes...)
+	const statusIndex = 3
 
-	err := doInner(ctx)
-	if err != nil {
-		span.SetStatus(codes.Error, err.Error())
-		return err
-	}
+	var (
+		begin    = time.Now()
+		err      error
+		panicked = true // set to false if program leaves normally
+	)
+	defer func() {
+		durationSeconds := time.Since(begin).Seconds()
 
-	span.SetStatus(codes.Ok, "")
-	m.metrics.insertCount.Add(ctx, 1, metric.WithAttributes(attributes...))
+		setAttributeAndSpanStatus(attrs, statusIndex, span, panicked, err)
 
+		// This allocates a new slice, so make sure to do it as few times as possible.
+		measurementOpt := metric.WithAttributes(attrs...)
+
+		m.metrics.jobWork.Add(ctx, 1, measurementOpt)
+		m.metrics.jobWorkDuration.Record(ctx, durationSeconds, measurementOpt)
+		m.metrics.jobWorkDurationHistogram.Record(ctx, durationSeconds, measurementOpt)
+	}()
+
+	err = doInner(ctx)
+	panicked = false
 	return err
+}
+
+func mustFloat64Gauge(meter metric.Meter, name string, options ...metric.Float64GaugeOption) metric.Float64Gauge {
+	metric, err := meter.Float64Gauge(name, options...)
+	if err != nil {
+		panic(err)
+	}
+	return metric
+}
+
+func mustFloat64Histogram(meter metric.Meter, name string, options ...metric.Float64HistogramOption) metric.Float64Histogram {
+	metric, err := meter.Float64Histogram(name, options...)
+	if err != nil {
+		panic(err)
+	}
+	return metric
+}
+
+func mustInt64Counter(meter metric.Meter, name string, options ...metric.Int64CounterOption) metric.Int64Counter {
+	metric, err := meter.Int64Counter(name, options...)
+	if err != nil {
+		panic(err)
+	}
+	return metric
+}
+
+// Sets success status on the given span and within the set of attributes. The
+// index of the status attribute is required ahead of time as a minor
+// optimization.
+func setAttributeAndSpanStatus(attrs []attribute.KeyValue, statusIndex int, span trace.Span, panicked bool, err error) {
+	if attrs[statusIndex].Key != "status" {
+		panic("status attribute not at expected index; bug?") // protect against future regression
+	}
+
+	switch {
+	case panicked:
+		attrs[statusIndex] = attribute.String("status", "panic")
+		span.SetStatus(codes.Error, "panic")
+	case err != nil:
+		attrs[statusIndex] = attribute.String("status", "error")
+		span.SetStatus(codes.Error, err.Error())
+	default:
+		attrs[statusIndex] = attribute.String("status", "ok")
+		span.SetStatus(codes.Ok, "")
+	}
+	span.SetAttributes(attrs...) // set after finalizing status
 }

--- a/otelriver/middleware_test.go
+++ b/otelriver/middleware_test.go
@@ -6,6 +6,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
 	sdktrace "go.opentelemetry.io/otel/sdk/trace"
 	"go.opentelemetry.io/otel/sdk/trace/tracetest"
@@ -61,6 +62,7 @@ func TestMiddleware(t *testing.T) {
 		require.Len(t, spans, 1)
 
 		span := spans[0]
+		require.Equal(t, "ok", getAttribute(t, span.Attributes, "status").AsString())
 		require.Equal(t, "river.insert_many", span.Name)
 		require.Equal(t, codes.Ok, span.Status.Code)
 	})
@@ -81,9 +83,33 @@ func TestMiddleware(t *testing.T) {
 		require.Len(t, spans, 1)
 
 		span := spans[0]
+		require.Equal(t, "error", getAttribute(t, span.Attributes, "status").AsString())
 		require.Equal(t, "river.insert_many", span.Name)
 		require.Equal(t, codes.Error, span.Status.Code)
 		require.Equal(t, "error from doInner", span.Status.Description)
+	})
+
+	t.Run("InsertManyPanic", func(t *testing.T) {
+		t.Parallel()
+
+		middleware, bundle := setup(t)
+
+		doInner := func(ctx context.Context) ([]*rivertype.JobInsertResult, error) {
+			panic("panic from doInner")
+		}
+
+		require.PanicsWithValue(t, "panic from doInner", func() {
+			_, _ = middleware.InsertMany(ctx, []*rivertype.JobInsertParams{{Kind: "no_op"}}, doInner)
+		})
+
+		spans := bundle.exporter.GetSpans()
+		require.Len(t, spans, 1)
+
+		span := spans[0]
+		require.Equal(t, "panic", getAttribute(t, span.Attributes, "status").AsString())
+		require.Equal(t, "river.insert_many", span.Name)
+		require.Equal(t, codes.Error, span.Status.Code)
+		require.Equal(t, "panic", span.Status.Description)
 	})
 
 	// Make sure the middleware can fall back to a global provider.
@@ -111,13 +137,20 @@ func TestMiddleware(t *testing.T) {
 			return nil
 		}
 
-		err := middleware.Work(ctx, &rivertype.JobRow{Kind: "no_op"}, doInner)
+		err := middleware.Work(ctx, &rivertype.JobRow{
+			Attempt: 6,
+			Kind:    "no_op",
+			Queue:   "my_queue",
+		}, doInner)
 		require.NoError(t, err)
 
 		spans := bundle.exporter.GetSpans()
 		require.Len(t, spans, 1)
 
 		span := spans[0]
+		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
+		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
+		require.Equal(t, "ok", getAttribute(t, span.Attributes, "status").AsString())
 		require.Equal(t, "river.work", span.Name)
 		require.Equal(t, codes.Ok, span.Status.Code)
 	})
@@ -131,16 +164,52 @@ func TestMiddleware(t *testing.T) {
 			return errors.New("error from doInner")
 		}
 
-		err := middleware.Work(ctx, &rivertype.JobRow{Kind: "no_op"}, doInner)
+		err := middleware.Work(ctx, &rivertype.JobRow{
+			Attempt: 6,
+			Kind:    "no_op",
+			Queue:   "my_queue",
+		}, doInner)
 		require.EqualError(t, err, "error from doInner")
 
 		spans := bundle.exporter.GetSpans()
 		require.Len(t, spans, 1)
 
 		span := spans[0]
+		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
+		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
+		require.Equal(t, "error", getAttribute(t, span.Attributes, "status").AsString())
 		require.Equal(t, "river.work", span.Name)
 		require.Equal(t, codes.Error, span.Status.Code)
 		require.Equal(t, "error from doInner", span.Status.Description)
+	})
+
+	t.Run("WorkPanic", func(t *testing.T) {
+		t.Parallel()
+
+		middleware, bundle := setup(t)
+
+		doInner := func(ctx context.Context) error {
+			panic("panic from doInner")
+		}
+
+		require.PanicsWithValue(t, "panic from doInner", func() {
+			_ = middleware.Work(ctx, &rivertype.JobRow{
+				Attempt: 6,
+				Kind:    "no_op",
+				Queue:   "my_queue",
+			}, doInner)
+		})
+
+		spans := bundle.exporter.GetSpans()
+		require.Len(t, spans, 1)
+
+		span := spans[0]
+		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
+		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
+		require.Equal(t, "panic", getAttribute(t, span.Attributes, "status").AsString())
+		require.Equal(t, "river.work", span.Name)
+		require.Equal(t, codes.Error, span.Status.Code)
+		require.Equal(t, "panic", span.Status.Description)
 	})
 
 	// Make sure the middleware can fall back to a global provider.
@@ -156,4 +225,16 @@ func TestMiddleware(t *testing.T) {
 		err := middleware.Work(ctx, &rivertype.JobRow{Kind: "no_op"}, doInner)
 		require.NoError(t, err)
 	})
+}
+
+func getAttribute(t *testing.T, attrs []attribute.KeyValue, key string) attribute.Value {
+	t.Helper()
+
+	for _, attr := range attrs {
+		if attr.Key == attribute.Key(key) {
+			return attr.Value
+		}
+	}
+	require.FailNow(t, "key not found in attributes: "+key)
+	return attribute.Value{}
 }


### PR DESCRIPTION
A bit of a miscellaneous bucket:

* A few additional metrics including metric duration as a gauge and
  histogram.

* An additional `status` attribute that can be used to filter said
  duration metrics by either success (`ok`) or failure (`error`,
  `panic`).

* Add units to all metrics (either seconds as `s` or `{job}` for
  counters).

* Handle panics gracefully such that all expected metric and span work
  still happens in the event of a panic.

* Tighten up conventions around metric naming.