### PR TITLE
Prepare release v0.1.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,14 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.0] - 2025-03-16
+
+### Added
+
+Initial release. Mainly brings in the `otelriver` package for use of River with OpenTelemetry and DataDog. [PR #1](https://github.com/riverqueue/rivercontrib/pull/1).

--- a/Makefile
+++ b/Makefile
@@ -41,3 +41,11 @@ define tidy-target
     tidy:: ; cd $1 && go mod tidy
 endef
 $(foreach mod,$(submodules),$(eval $(call tidy-target,$(mod))))
+
+.PHONY: update-mod-go
+update-mod-go: ## Update `go`/`toolchain` directives in all submodules to match `go.work`
+	PACKAGE_PREFIX="github.com/riverqueue/rivercontrib" go run github.com/riverqueue/river/rivershared/cmd/update-mod-go@latest ./go.work
+
+.PHONY: update-mod-version
+update-mod-version: ## Update River packages in all submodules to $VERSION
+	go run github.com/riverqueue/river/rivershared/cmd/update-mod-version@latest ./go.work

--- a/datadogriver/go.mod
+++ b/datadogriver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.19.0
 	github.com/riverqueue/river/rivershared v0.19.0
 	github.com/riverqueue/river/rivertype v0.19.0
-	github.com/riverqueue/rivercontrib/otelriver v0.0.0-20250316234026-fc1c8cd5c761
+	github.com/riverqueue/rivercontrib/otelriver v0.1.0
 	go.opentelemetry.io/otel v1.35.0
 )
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -1,0 +1,43 @@
+# rivercontrib development
+
+## Run tests
+
+Run tests:
+
+    make test
+
+## Run lint
+
+Run the linter and try to autofix:
+
+    make lint
+
+## Releasing a new version
+
+1. Fetch changes to the repo and any new tags. Export `VERSION` by incrementing the last tag. Execute `update-mod-version` to add it the project's `go.mod` files:
+
+    ```shell
+    git checkout master && git pull --rebase
+    export VERSION=v0.x.y
+    make update-mod-version
+    git checkout -b $USER-$VERSION
+    ```
+
+2. Prepare a PR with the changes, updating `CHANGELOG.md` with any necessary additions at the same time. Include **`[skip ci]`** in the commit description so that CI doesn't run and pollute the Go Module cache by trying to fetch a version that's not available yet (and it would fail anyway). Have it reviewed and merged.
+
+3. Upon merge, pull down the changes, tag each module with the new version, and push the new tags:
+
+    ```shell
+    git checkout master && git pull --rebase
+    git tag otelriver/$VERSION -m "release otelriver/$VERSION"
+    git tag datadogriver/$VERSION -m "release datadogriver/$VERSION"
+    git tag $VERSION
+    ```
+
+4. Push new tags to GitHub:
+
+    ```shell
+    git push --tags
+    ```
+
+5. Cut a new GitHub release by visiting [new release](https://github.com/riverqueue/rivercontrib/releases/new), selecting the new tag, and copying in the version's `CHANGELOG.md` content as the release body.


### PR DESCRIPTION
Prepare release v0.1.0, containing the initial stab at `otelriver`. Also
bundle in a few useful make targets, a changelog, and an initial stab at
a doc containing development instructions.

[skip ci]