### PR TITLE
Add option to make metric duration unit configurable + testing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `otelriver` option `MiddlewareConfig.DurationUnit`. Can be used to configure duration metrics to be emitted in milliseconds instead of the default seconds. [PR #XXX](https://github.com/riverqueue/rivercontrib/pull/XXX).
+
 ## [0.1.0] - 2025-03-16
 
 ### Added
 
-Initial release. Mainly brings in the `otelriver` package for use of River with OpenTelemetry and DataDog. [PR #1](https://github.com/riverqueue/rivercontrib/pull/1).
+- Initial release. Mainly brings in the `otelriver` package for use of River with OpenTelemetry and DataDog. [PR #1](https://github.com/riverqueue/rivercontrib/pull/1).


### PR DESCRIPTION
Here, bring in a new option `MiddlewareConfig.DurationUnit` which can be
used to change the default duration of duration-based metrics from
seconds to milliseconds. There seems to be a reasonable number of people
in both the seconds and milliseconds camps [1], so it seems okay to make
this configurable.

The first release also didn't bother testing metrics (since at the time,
I couldn't find a testing package for metrics like existed for traces),
so we also bring in metrics tests for the existing behavior along with
the new `DurationUnit` option.

Also fixes a small bug wherein attributes weren't being assigned as
expected to a couple of the metrics.

Fixes #9.

[1] https://github.com/open-telemetry/opentelemetry-specification/issues/2977