### PR TITLE
Add middleware options to README

### DIFF
--- a/otelriver/README.md
+++ b/otelriver/README.md
@@ -4,6 +4,22 @@
 
 See [`example_middleware_test.go`](./example_middleware_test.go) for usage details.
 
+## Options
+
+The middleware supports these options:
+
+``` go
+middleware := otelriver.NewMiddleware(&MiddlewareConfig{
+    DurationUnit:   "ms",
+    MeterProvider:  meterProvider,
+    TracerProvider: tracerProvider,
+})
+```
+
+* `DurationUnit`: The unit which durations are emitted as, either "ms" (milliseconds) or "s" (seconds). Defaults to seconds.
+* `MeterProvider`: Injected OpenTelemetry meter provider. The global meter provider is used by default.
+* `TracerProvider`: Injected OpenTelemetry tracer provider. The global tracer provider is used by default.
+
 ## Use with DataDog
 
 See [using the OpenTelemetry API with DataDog](https://docs.datadoghq.com/tracing/trace_collection/custom_instrumentation/go/otel/) and the examples in [`datadogriver`](../datadogriver/) for how to configure a DataDog OpenTelemetry tracer provider.


### PR DESCRIPTION
Add middleware options to the OpenTelemetry package's README. Gives them
another place where they're more obvious to find and quickly scan for use.