### PR TITLE
Add `EnableSemanticMetrics` setting to emit "semantic" metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Added `otelriver` option `MiddlewareConfig.DurationUnit`. Can be used to configure duration metrics to be emitted in milliseconds instead of the default seconds. [PR #XXX](https://github.com/riverqueue/rivercontrib/pull/XXX).
+- Added `otelriver` option `MiddlewareConfig.DurationUnit`. Can be used to configure duration metrics to be emitted in milliseconds instead of the default seconds. [PR #10](https://github.com/riverqueue/rivercontrib/pull/10).
+- More attributes like job ID and timestamps on OpenTelemetry spans. [PR #11](https://github.com/riverqueue/rivercontrib/pull/11).
+- Added `otelriver` option `EnableSemanticMetrics` which will cause the middleware to emit metrics compliant with OpenTelemetry [semantic conventions](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/). [PR #12](https://github.com/riverqueue/rivercontrib/pull/12).
 
 ## [0.1.0] - 2025-03-16
 

--- a/otelriver/README.md
+++ b/otelriver/README.md
@@ -10,13 +10,15 @@ The middleware supports these options:
 
 ``` go
 middleware := otelriver.NewMiddleware(&MiddlewareConfig{
-    DurationUnit:   "ms",
-    MeterProvider:  meterProvider,
-    TracerProvider: tracerProvider,
+    DurationUnit:          "ms",
+    EnableSemanticMetrics: true,
+    MeterProvider:         meterProvider,
+    TracerProvider:        tracerProvider,
 })
 ```
 
 * `DurationUnit`: The unit which durations are emitted as, either "ms" (milliseconds) or "s" (seconds). Defaults to seconds.
+* `EnableSemanticMetrics`: Causes the middleware to emit metrics compliant with OpenTelemetry's ["semantic conventions"](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/) for message clients. This has the effect of having all messaging systems share the same common metric names, with attributes differentiating them.
 * `MeterProvider`: Injected OpenTelemetry meter provider. The global meter provider is used by default.
 * `TracerProvider`: Injected OpenTelemetry tracer provider. The global tracer provider is used by default.
 


### PR DESCRIPTION
Here, address #7 to bring in a new option `EnableSemanticMetrics` that
causes the middleware to emit metrics compliant with OpenTelemetry's
"semantic conventions" [1]. These are a way to have all pub/sub systems
emit metrics with the same name and differentiated by attribute.

I've put this behind a configuration option because I'm not super
convinced that this is going to be an important feature for most people,
and under the assumption that metrics are cheap but not free, it
probably makes sense to emit only as many as necessary.

Fixes #7.

[1] https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/