### PR TITLE
Add `EnableWorkSpanJobKindSuffix` to optionally add job kind suffix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Added `otelriver` option `EnableWorkSpanJobKindSuffix` which appends the job kind a suffix to work spans so they look like `river.work/my_job` instead of `river.work`.
+
 ## [0.3.0] - 2025-04-14
 
 ### Added

--- a/otelriver/README.md
+++ b/otelriver/README.md
@@ -10,15 +10,17 @@ The middleware supports these options:
 
 ``` go
 middleware := otelriver.NewMiddleware(&MiddlewareConfig{
-    DurationUnit:          "ms",
-    EnableSemanticMetrics: true,
-    MeterProvider:         meterProvider,
-    TracerProvider:        tracerProvider,
+    DurationUnit:                "ms",
+    EnableSemanticMetrics:       true,
+    EnableWorkSpanJobKindSuffix: true,
+    MeterProvider:               meterProvider,
+    TracerProvider:              tracerProvider,
 })
 ```
 
 * `DurationUnit`: The unit which durations are emitted as, either "ms" (milliseconds) or "s" (seconds). Defaults to seconds.
 * `EnableSemanticMetrics`: Causes the middleware to emit metrics compliant with OpenTelemetry's ["semantic conventions"](https://opentelemetry.io/docs/specs/semconv/messaging/messaging-metrics/) for message clients. This has the effect of having all messaging systems share the same common metric names, with attributes differentiating them.
+* `EnableWorkSpanJobKindSuffix`: Appends the job kind a suffix to work spans so they look like `river.work/my_job` instead of `river.work`.
 * `MeterProvider`: Injected OpenTelemetry meter provider. The global meter provider is used by default.
 * `TracerProvider`: Injected OpenTelemetry tracer provider. The global tracer provider is used by default.
 

--- a/otelriver/middleware.go
+++ b/otelriver/middleware.go
@@ -179,7 +179,7 @@ func (m *Middleware) InsertMany(ctx context.Context, manyParams []*rivertype.Job
 }
 
 func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner func(context.Context) error) error {
-	ctx, span := m.tracer.Start(ctx, prefix+"work",
+	ctx, span := m.tracer.Start(ctx, prefix+"work/"+job.Kind,
 		trace.WithSpanKind(trace.SpanKindConsumer))
 	defer span.End()
 

--- a/otelriver/middleware_test.go
+++ b/otelriver/middleware_test.go
@@ -295,7 +295,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, "ok", getAttribute(t, span.Attributes, "status").AsString())
 		require.Equal(t, scheduledAt.Format(time.RFC3339), getAttribute(t, span.Attributes, "scheduled_at").AsString())
 		require.Equal(t, []string{"a", "b"}, getAttribute(t, span.Attributes, "tag").AsStringSlice())
-		require.Equal(t, "river.work", span.Name)
+		require.Equal(t, "river.work/no_op", span.Name)
 		require.Equal(t, codes.Ok, span.Status.Code)
 
 		var (
@@ -344,7 +344,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
 		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
 		require.Equal(t, "error", getAttribute(t, span.Attributes, "status").AsString())
-		require.Equal(t, "river.work", span.Name)
+		require.Equal(t, "river.work/no_op", span.Name)
 		require.Equal(t, codes.Error, span.Status.Code)
 		require.Equal(t, "error from doInner", span.Status.Description)
 
@@ -426,7 +426,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
 		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
 		require.Equal(t, "panic", getAttribute(t, span.Attributes, "status").AsString())
-		require.Equal(t, "river.work", span.Name)
+		require.Equal(t, "river.work/no_op", span.Name)
 		require.Equal(t, codes.Error, span.Status.Code)
 		require.Equal(t, "panic", span.Status.Description)
 

--- a/otelriver/middleware_test.go
+++ b/otelriver/middleware_test.go
@@ -295,7 +295,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, "ok", getAttribute(t, span.Attributes, "status").AsString())
 		require.Equal(t, scheduledAt.Format(time.RFC3339), getAttribute(t, span.Attributes, "scheduled_at").AsString())
 		require.Equal(t, []string{"a", "b"}, getAttribute(t, span.Attributes, "tag").AsStringSlice())
-		require.Equal(t, "river.work/no_op", span.Name)
+		require.Equal(t, "river.work", span.Name)
 		require.Equal(t, codes.Ok, span.Status.Code)
 
 		var (
@@ -344,7 +344,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
 		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
 		require.Equal(t, "error", getAttribute(t, span.Attributes, "status").AsString())
-		require.Equal(t, "river.work/no_op", span.Name)
+		require.Equal(t, "river.work", span.Name)
 		require.Equal(t, codes.Error, span.Status.Code)
 		require.Equal(t, "error from doInner", span.Status.Description)
 
@@ -426,7 +426,7 @@ func TestMiddleware(t *testing.T) {
 		require.Equal(t, int64(6), getAttribute(t, span.Attributes, "attempt").AsInt64())
 		require.Equal(t, "my_queue", getAttribute(t, span.Attributes, "queue").AsString())
 		require.Equal(t, "panic", getAttribute(t, span.Attributes, "status").AsString())
-		require.Equal(t, "river.work/no_op", span.Name)
+		require.Equal(t, "river.work", span.Name)
 		require.Equal(t, codes.Error, span.Status.Code)
 		require.Equal(t, "panic", span.Status.Description)
 
@@ -516,6 +516,30 @@ func TestMiddleware(t *testing.T) {
 			metric, _ := requireHistogramCount(t, metrics, "messaging.process.duration", 1, expectedAttrs...)
 			require.Equal(t, "s", metric.Unit)
 		}
+	})
+
+	t.Run("WorkEnableWorkSpanJobKindSuffix ", func(t *testing.T) {
+		t.Parallel()
+
+		middleware, bundle := setupConfig(t, &MiddlewareConfig{
+			EnableWorkSpanJobKindSuffix: true,
+		})
+
+		doInner := func(ctx context.Context) error {
+			return nil
+		}
+
+		err := middleware.Work(ctx, &rivertype.JobRow{
+			ID:   123,
+			Kind: "no_op",
+		}, doInner)
+		require.NoError(t, err)
+
+		spans := bundle.traceExporter.GetSpans()
+		require.Len(t, spans, 1)
+
+		span := spans[0]
+		require.Equal(t, "river.work/no_op", span.Name)
 	})
 }
 


### PR DESCRIPTION
Follows up #22 to make the job kind suffix on work spans configurable using the
new setting `EnableWorkSpanJobKindSuffix` which will make work spans named like
`river.work/no_op`. This makes the feature available for those who'd prefer it,
but it's not default.