### PR TITLE
Prepare release v0.5.0

### DIFF
--- a/datadogriver/go.mod
+++ b/datadogriver/go.mod
@@ -10,7 +10,7 @@ require (
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.21.0
 	github.com/riverqueue/river/rivershared v0.21.0
 	github.com/riverqueue/river/rivertype v0.21.0
-	github.com/riverqueue/rivercontrib/otelriver v0.4.0
+	github.com/riverqueue/rivercontrib/otelriver v0.5.0
 	go.opentelemetry.io/otel v1.35.0
 )
 

--- a/docs/development.md
+++ b/docs/development.md
@@ -29,8 +29,9 @@ Run the linter and try to autofix:
 
     ```shell
     git checkout master && git pull --rebase
-    git tag otelriver/$VERSION -m "release otelriver/$VERSION"
     git tag datadogriver/$VERSION -m "release datadogriver/$VERSION"
+    git tag nilerror/$VERSION -m "release nilerror/$VERSION"
+    git tag otelriver/$VERSION -m "release otelriver/$VERSION"
     git tag $VERSION
     ```
 


### PR DESCRIPTION
Prepare release v0.5.0 which largely includes the new `nilerror` package
from #25.

[skip ci]