### PR TITLE
Prepare release 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.0] - 2026-05-15
+
+### Added
+
+- Augment `otelriver` middleware to cleanly handle errors returned in batch results from River Pro's batch jobs feature. [PR #54](https://github.com/riverqueue/rivercontrib/pull/54).
+
 ## [0.7.0] - 2026-01-18
 
 ### Added

--- a/datadogriver/go.mod
+++ b/datadogriver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0
 	github.com/riverqueue/river/rivershared v0.29.0
 	github.com/riverqueue/river/rivertype v0.29.0
-	github.com/riverqueue/rivercontrib/otelriver v0.7.0
+	github.com/riverqueue/rivercontrib/otelriver v0.8.0
 	go.opentelemetry.io/otel v1.43.0
 )
 


### PR DESCRIPTION
Prepare release 0.8.0, including an OTEL enhancement that properly
attributes errors that are returned from River Pro batch results.

[skip ci]