### PR TITLE
otelriver: treat JobSnoozeError as flow control, not a failure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Record snoozed jobs with status `ok` instead of `error` in `otelriver` middleware. Add new `snooze.duration` span attribute. [PR #59](https://github.com/riverqueue/rivercontrib/pull/59).
+
 ## [0.8.0] - 2026-05-15
 
 ### Added

--- a/otelriver/middleware.go
+++ b/otelriver/middleware.go
@@ -210,6 +210,11 @@ func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner fu
 	defer func() {
 		duration := m.durationInPreferredUnit(time.Since(begin))
 
+		var (
+			cancelErr *river.JobCancelError
+			snoozeErr *river.JobSnoozeError
+		)
+
 		if err != nil {
 			var batchResult interface { // To be superseded if riverbatch.MultiError is moved to rivertype.
 				ErrorsByID() map[int64]error
@@ -217,11 +222,6 @@ func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner fu
 			if errors.As(err, &batchResult) {
 				err = batchResult.ErrorsByID()[job.ID]
 			}
-
-			var (
-				cancelErr *river.JobCancelError
-				snoozeErr *river.JobSnoozeError
-			)
 
 			switch {
 			case errors.As(err, &cancelErr):
@@ -233,16 +233,17 @@ func (m *Middleware) Work(ctx context.Context, job *rivertype.JobRow, doInner fu
 
 		setStatus(attrs, statusIndex, span, panicked, err)
 
-		{
-			// Add some higher cardinality attributes to spans, but keep them
-			// out of metrics given it's been traditional wisdom that metric
-			// attribute sets shouldn't be too large.
-			attrs := append(attrs,
-				attribute.Int64("id", job.ID),
-				attribute.String("created_at", job.CreatedAt.Format(time.RFC3339)),
-				attribute.String("scheduled_at", job.ScheduledAt.Format(time.RFC3339)),
-			)
-			span.SetAttributes(attrs...) // set after finalizing status
+		// Add some higher cardinality attributes to spans, but keep them
+		// out of metrics given it's been traditional wisdom that metric
+		// attribute sets shouldn't be too large.
+		span.SetAttributes(
+			attribute.Int64("id", job.ID),
+			attribute.String("created_at", job.CreatedAt.Format(time.RFC3339)),
+			attribute.String("scheduled_at", job.ScheduledAt.Format(time.RFC3339)),
+		)
+		span.SetAttributes(attrs...) // set after finalizing status
+		if snoozeErr != nil {
+			span.SetAttributes(attribute.String("snooze.duration", snoozeErr.Duration.String()))
 		}
 
 		// This allocates a new slice, so make sure to do it as few times as possible.
@@ -316,6 +317,13 @@ func setStatus(attrs []attribute.KeyValue, statusIndex int, span trace.Span, pan
 	case panicked:
 		attrs[statusIndex] = attribute.String("status", "panic")
 		span.SetStatus(codes.Error, "panic")
+	case errors.Is(err, &river.JobSnoozeError{}):
+		// Snooze is flow control, not failure: the job will be retried
+		// later. Record as ok so it doesn't pollute error rates; the
+		// snooze:true span/metric attribute (set by the caller) keeps
+		// snoozes queryable as a dimension.
+		attrs[statusIndex] = attribute.String("status", "ok")
+		span.SetStatus(codes.Ok, "")
 	case err != nil:
 		attrs[statusIndex] = attribute.String("status", "error")
 		span.SetStatus(codes.Error, err.Error())

--- a/otelriver/middleware_test.go
+++ b/otelriver/middleware_test.go
@@ -387,19 +387,37 @@ func TestMiddleware(t *testing.T) {
 		middleware, bundle := setup(t)
 
 		doInner := func(ctx context.Context) error {
-			return fmt.Errorf("wrapped job snooze: %w", &rivertype.JobSnoozeError{})
+			return fmt.Errorf("wrapped job snooze: %w", &rivertype.JobSnoozeError{Duration: 5 * time.Second})
 		}
 
 		err := middleware.Work(ctx, &rivertype.JobRow{
 			Kind: "no_op",
 		}, doInner)
-		require.EqualError(t, err, "wrapped job snooze: JobSnoozeError: 0s")
+		require.EqualError(t, err, "wrapped job snooze: JobSnoozeError: 5s")
 
 		spans := bundle.traceExporter.GetSpans()
 		require.Len(t, spans, 1)
 
 		span := spans[0]
 		require.True(t, getAttribute(t, span.Attributes, "snooze").AsBool())
+		// Snooze is flow control, not failure: span status is ok and the
+		// snooze.duration is recorded as a span-only attribute.
+		require.Equal(t, "ok", getAttribute(t, span.Attributes, "status").AsString())
+		require.Equal(t, codes.Ok, span.Status.Code)
+		require.Equal(t, "5s", getAttribute(t, span.Attributes, "snooze.duration").AsString())
+
+		// The metric records status:ok with snooze:true so snoozes remain
+		// queryable as a metric dimension without counting against the
+		// error rate.
+		var (
+			expectedAttrs = []attribute.KeyValue{
+				attribute.String("status", "ok"),
+				attribute.Bool("snooze", true),
+			}
+			metrics metricdata.ResourceMetrics
+		)
+		require.NoError(t, bundle.metricReader.Collect(ctx, &metrics))
+		requireSum(t, metrics, "river.work_count", 1, expectedAttrs...)
 	})
 
 	t.Run("WorkBatchResultWithJobError", func(t *testing.T) {
@@ -476,7 +494,7 @@ func TestMiddleware(t *testing.T) {
 
 		doInner := func(ctx context.Context) error {
 			return &fakeBatchError{errorsByID: map[int64]error{
-				123: &rivertype.JobSnoozeError{},
+				123: &rivertype.JobSnoozeError{Duration: 7 * time.Second},
 			}}
 		}
 
@@ -488,6 +506,19 @@ func TestMiddleware(t *testing.T) {
 
 		span := spans[0]
 		require.True(t, getAttribute(t, span.Attributes, "snooze").AsBool())
+		require.Equal(t, "ok", getAttribute(t, span.Attributes, "status").AsString())
+		require.Equal(t, codes.Ok, span.Status.Code)
+		require.Equal(t, "7s", getAttribute(t, span.Attributes, "snooze.duration").AsString())
+
+		var (
+			expectedAttrs = []attribute.KeyValue{
+				attribute.String("status", "ok"),
+				attribute.Bool("snooze", true),
+			}
+			metrics metricdata.ResourceMetrics
+		)
+		require.NoError(t, bundle.metricReader.Collect(ctx, &metrics))
+		requireSum(t, metrics, "river.work_count", 1, expectedAttrs...)
 	})
 
 	t.Run("WorkPanic", func(t *testing.T) {


### PR DESCRIPTION
## What

Today a job that returns `JobSnoozeError` (the standard way to ask River to re-schedule a job) flows through the same path as a real failure:

- the `river.work` span is set to `codes.Error` with the snooze error as the description
- the `river.work_count` metric records `status:error,snooze:true`

This PR teaches `setStatus` to recognize `*rivertype.JobSnoozeError` and treat it as success, mirroring the way `JobCancelError` is already special-cased on the attribute side. Concretely:

| Path | Before | After |
|---|---|---|
| `river.work_count` | `status:error,snooze:true` | `status:ok,snooze:true` |
| Span status | `codes.Error` + snooze err description | `codes.Ok` |
| Span attributes | `snooze:true` | `snooze:true`, `snooze.duration:\"5s\"` (new) |

The `snooze:true` attribute (already set in the existing `errors.As` switch) is preserved on both the span and the metric, so snoozes remain queryable as a dimension, they just don't pollute error rates anymore.

## Why

Snoozes aren't failures. The job is explicitly asking *\"come back to me later\"* and River does exactly that. Recording them as `codes.Error` in spans means:

- the river.work span in traces appears red even for healthy, expected behaviour
- every chart that wants a real error rate has to defensively exclude `snooze:true` (and people frequently forget, so error rates get inflated by however many snoozes a given workload uses for backoff / flow control)

It also makes the snooze duration cumbersome to extract (today you'd have to parse the error string). After this change it's a discrete span attribute (`snooze.duration:\"5s\"`).

The same arguably applies to `JobCancelError` (the existing `cancel:true` attribute follows the same shape), but cancellations could be considered errors in some workloads, so I scoped this to `snooze` only.

## Alternatives considered

Arguably it would make more sense to roll snooze and cancel into `status` and get rid of the existing `snooze` and `cancel` attributes, but that could break existing metric queries, so I did not take that approach:

| Before | After |
|---|---|
| `status:error,snooze:true` | `status:snoozed` |
| `status:error,cancel:true` | `status:cancelled` |

## Tests

The two existing snooze test cases (`JobSnoozeError` and `WorkBatchResultWithJobSnoozeError`) are extended to:

- give the snooze error a non-zero `Duration` (5s and 7s respectively)
- assert `status:ok` and `codes.Ok` on the span
- assert `snooze.duration` on the span
- assert `river.work_count{status:ok,snooze:true}` on the metric

`make test` and `make lint` both pass; tests also pass under `-race`.

## Notes for reviewers

- Sibling PR — same area, independent change: [otelriver: partition river.insert_count by skipped_as_duplicate](https://github.com/riverqueue/rivercontrib/pull/58)
- This is a behavioural change for anyone currently filtering on `status:error` in dashboards/alerts. Existing queries that filter `snooze:true` will continue to work; queries that don't filter and rely on snoozes counting as errors will need a small update.

---
Made with Cursor on behalf of [@echatman](https://github.com/echatman).

Made with [Cursor](https://cursor.com)