### PR TITLE
Prepare release v0.9.0

### DIFF
--- a/datadogriver/go.mod
+++ b/datadogriver/go.mod
@@ -8,7 +8,7 @@ require (
 	github.com/riverqueue/river/riverdriver/riverpgxv5 v0.29.0
 	github.com/riverqueue/river/rivershared v0.29.0
 	github.com/riverqueue/river/rivertype v0.29.0
-	github.com/riverqueue/rivercontrib/otelriver v0.8.0
+	github.com/riverqueue/rivercontrib/otelriver v0.9.0
 	go.opentelemetry.io/otel v1.43.0
 )
 


### PR DESCRIPTION
Prepare release v0.9.0, containing #58 and #59 for `otelriver`.

[skip ci]